### PR TITLE
chore: ignore .netlify cache + migrate Claude hook schema

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -3,13 +3,21 @@
     "PostToolUse": [
       {
         "matcher": "Write|Edit",
-        "command": "node scripts/harness/claude-format.js",
-        "description": "Format + lint Claude TS/JS/docs edits"
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node scripts/harness/claude-format.js"
+          }
+        ]
       },
       {
         "matcher": "Write|Edit",
-        "command": "node scripts/harness/claude-ruff.js",
-        "description": "Format + lint Claude Python edits"
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node scripts/harness/claude-ruff.js"
+          }
+        ]
       }
     ]
   }

--- a/.gitignore
+++ b/.gitignore
@@ -46,6 +46,9 @@ env
 # vercel
 .vercel
 
+# netlify CLI cache
+.netlify/
+
 # typescript
 *.tsbuildinfo
 next-env.d.ts


### PR DESCRIPTION
## Summary
- `.gitignore`: add `.netlify/` (Netlify CLI plugin cache, never source-valuable).
- `.claude/settings.json`: migrate PostToolUse entries to the nested `hooks` array form expected by the current Claude Code hook schema.

## Test plan
- [ ] CI green
- [ ] Local: editing a TS file still triggers `claude-format.js`; editing a Python file still triggers `claude-ruff.js`.