### PR TITLE
feat(e2e): add e2e:rebuild for in-place image rebuilds

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,15 +78,16 @@ pages/          legacy error fallbacks (do not add new routes here)
 
 ## E2E Harness Cheatsheet
 
-| Command                        | What it does                                                       |
-| ------------------------------ | ------------------------------------------------------------------ |
-| `npm run e2e:up`               | Boot compose stack, run migrations, seed. Idempotent.              |
-| `npm run e2e:explore`          | Boot only. Stack stays up for manual testing or MCP-driven agents. |
-| `npm run e2e:reset`            | Truncate DB and re-seed.                                           |
-| `npm run e2e:down`             | Stop and remove containers + volumes.                              |
-| `npm run e2e:agent`            | Run Playwright in agent mode; emits `.e2e/runs/latest/summary.md`. |
-| `npm run e2e:debug -- <runId>` | Print run summary plus the last 50 lines of api/web logs.          |
-| `npm run e2e`                  | Legacy fast path: dev `webServer`, no compose. Smoke only.         |
+| Command                        | What it does                                                               |
+| ------------------------------ | -------------------------------------------------------------------------- |
+| `npm run e2e:up`               | Boot compose stack, run migrations, seed. Idempotent.                      |
+| `npm run e2e:explore`          | Boot only. Stack stays up for manual testing or MCP-driven agents.         |
+| `npm run e2e:reset`            | Truncate DB and re-seed.                                                   |
+| `npm run e2e:down`             | Stop and remove containers + volumes.                                      |
+| `npm run e2e:agent`            | Run Playwright in agent mode; emits `.e2e/runs/latest/summary.md`.         |
+| `npm run e2e:debug -- <runId>` | Print run summary plus the last 50 lines of api/web logs.                  |
+| `npm run e2e:rebuild [svc]`    | Rebuild image(s) and restart in place. Omit `svc` for all, or `web`/`api`. |
+| `npm run e2e`                  | Legacy fast path: dev `webServer`, no compose. Smoke only.                 |
 
 Full operator guide: [docs/e2e.md](docs/e2e.md).
 

--- a/docs/e2e.md
+++ b/docs/e2e.md
@@ -12,6 +12,7 @@
 | `npm run e2e:agent`            | Runs Playwright in agent mode; emits `.e2e/runs/latest/summary.md`. |
 | `npm run e2e:explore`          | Boots stack only; prints MCP connect info.                          |
 | `npm run e2e:debug -- <runId>` | Prints summary + last 50 lines of api/web logs.                     |
+| `npm run e2e:rebuild [svc]`    | Rebuild image(s) and restart. Omit `svc` for all; or `web`/`api`.   |
 | `npm run e2e`                  | Legacy fast path: dev `webServer`, no compose. Smoke only.          |
 
 ## Agent TDD loop

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "e2e:agent": "tsx scripts/e2e/agent.ts",
     "e2e:explore": "tsx scripts/e2e/explore.ts",
     "e2e:debug": "tsx scripts/e2e/debug.ts",
+    "e2e:rebuild": "tsx scripts/e2e/rebuild.ts",
     "e2e:ci": "E2E_AGENT=1 playwright test",
     "harness:prepush": "npm run typecheck && npm run lint && node scripts/harness/prisma-drift.js && npm run test:run && cd backend && .venv/bin/ruff check . && .venv/bin/ruff format --check . && .venv/bin/mypy app",
     "harness:full": "npm run harness:prepush && npm run e2e"

--- a/scripts/e2e/rebuild.ts
+++ b/scripts/e2e/rebuild.ts
@@ -1,0 +1,31 @@
+#!/usr/bin/env tsx
+import { execSync } from "node:child_process";
+
+const COMPOSE = "docker compose -p brand-creator-e2e -f docker/compose.e2e.yml";
+const REBUILDABLE = ["web", "api", "supabase", "pg"] as const;
+type Service = (typeof REBUILDABLE)[number];
+
+function parseService(argv: readonly string[]): Service | null {
+  const arg = argv[2];
+  if (!arg) return null;
+  if ((REBUILDABLE as readonly string[]).includes(arg)) return arg as Service;
+  console.error(
+    `[e2e:rebuild] unknown service "${arg}". Expected one of: ${REBUILDABLE.join(", ")} (or omit for all).`
+  );
+  process.exit(1);
+}
+
+function main(): void {
+  const service = parseService(process.argv);
+  const target = service ?? "(all services)";
+  console.log(`[e2e:rebuild] rebuilding ${target}…`);
+  const cmd = service
+    ? `${COMPOSE} up -d --build --wait ${service}`
+    : `${COMPOSE} up -d --build --wait`;
+  execSync(cmd, { stdio: "inherit" });
+  console.log(`[e2e:rebuild] ${target} ready.`);
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  main();
+}


### PR DESCRIPTION
## Summary
- Add `scripts/e2e/rebuild.ts` wrapping `docker compose up -d --build --wait` so source edits take effect without `down`/`up`.
- Optional service arg (`web`/`api`/`supabase`/`pg`); omit for all.
- Wired as `npm run e2e:rebuild`; documented in README + `docs/e2e.md` cheatsheets.

## Test plan
- [ ] `npm run e2e:up` boots stack; edit a `src/` file; `npm run e2e:rebuild web` reflects change.
- [ ] `npm run e2e:rebuild api` rebuilds backend only.
- [ ] `npm run e2e:rebuild bogus` exits non-zero with helpful error.
- [ ] CI green.